### PR TITLE
fix ' jsxc is not a command'

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "jsxc": "~0.1.6"
   },
   "scripts": {
-    "start": "jsxc --watch src/ lib/",
-    "build": "jsxc src/ lib/"
+    "start": "node ./node_modules/jsxc/bin/jsxc --watch src/ lib/",
+    "build": "node ./node_modules/jsxc/bin/jsxc src/ lib/"
   },
   "files": ["lib/", "USAGE.txt", "static/"],
   "staticRoot": "./static/",


### PR DESCRIPTION
when execute 'npm run build', I got a error : 'jsxc is not a command', because I didn't get jsxc installed globally before.